### PR TITLE
WP-341 Add 'access' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ wazo-debug capture
 
 The capture will start automatically. To stop the capture, hit CTRL-C. The
 capture file will be printed on the console.
+
+## wazo-debug access
+
+`wazo-debug access` open an access to this Platform even behind a NAT or a Firewall. This is done opening a SSH tunnel on a remote server, the local port being exposed on a random port on the remote server.
+
+### Usage
+
+```
+wazo-debug access
+```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wazo-debug (1.1.0) wazo-dev; urgency=medium
+
+  * Add access subcommand.
+
+ -- Wazo Maintainers <dev+pkg@wazo.community>  Mon, 08 Jul 2021 12:34:56 +0100
+
 wazo-debug (1.0.0) wazo-dev; urgency=medium
 
   * Initial release.

--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,11 @@ Architecture: all
 Depends:
  ${python3:Depends},
  ${misc:Depends},
+ coreutils,
+ openssh-client,
  python3-cliff,
  sngrep,
+ sshpass,
  whiptail
 Description: Wazo debug scripts
  Wazo is a system based on a powerful IPBX, to bring an easy to

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Depends:
  openssh-client,
  python3-cliff,
  sngrep,
- sshpass,
  whiptail
 Description: Wazo debug scripts
  Wazo is a system based on a powerful IPBX, to bring an easy to

--- a/debian/wazo-debug.lintian-overrides
+++ b/debian/wazo-debug.lintian-overrides
@@ -1,0 +1,1 @@
+wazo-debug: depends-on-essential-package-without-using-version depends: coreutils

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages
 
 setup(
     name='wazo-debug',
-    version='1.0',
+    version='1.1',
     author='Wazo Authors',
     author_email='dev@wazo.community',
     url='http://wazo.community',
@@ -18,6 +18,7 @@ setup(
             'wazo-debug = wazo_debug.main:main',
         ],
         'wazo_debug.commands': [
+            'access = wazo_debug.access:AccessCommand',
             'capture = wazo_debug.capture:CaptureCommand',
             'collect = wazo_debug.collect:CollectCommand',
         ],

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -36,24 +36,28 @@ class AccessCommand(Command):
             '-s',
             '--remote-server',
             action='store',
+            required=True,
             help='The remote server where the tunnel will be opened.',
         )
         parser.add_argument(
             '-r',
             '--remote-server-port',
             action='store',
+            required=True,
             help='The remote server port.',
         )
         parser.add_argument(
             '-u',
             '--remote-user',
             action='store',
+            required=True,
             help='The unix user on the remote server.',
         )
         parser.add_argument(
             '-i',
             '--identity',
             action='store',
+            required=True,
             help="The remote user's SSH private key file.",
         )
         parser.add_argument(

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -1,0 +1,112 @@
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import argparse
+import logging
+import random
+import time
+from subprocess import call
+from cliff.command import Command
+
+logger = logging.getLogger(__name__)
+
+
+class AccessCommand(Command):
+    """Open an access to this Platform even behind a NAT or a Firewall.
+    This is done opening a SSH tunnel on a remote server, the local port being exposed on a random port on the remote server.
+    """
+
+    def get_parser(self, program_name):
+        parser = argparse.ArgumentParser(
+            prog=program_name,
+            description='Open an access to this Platform even behind a NAT or a Firewall.',
+        )
+        parser.add_argument(
+            '-l',
+            '--local-port',
+            action='store',
+            help='The local port being exposed. Default to SSH port tcp/22.',
+            default=22,
+        )
+        parser.add_argument(
+            '-s',
+            '--remote-server',
+            action='store',
+            help='The remote server where the tunnel will be opened. Default to Wazo\' Support access server.',
+            default='support-access.wazo.io',
+        )
+        parser.add_argument(
+            '-r',
+            '--remote-server-port',
+            action='store',
+            help='The remote server port.',
+            default=22000,
+        )
+        parser.add_argument(
+            '-u',
+            '--remote-user',
+            action='store',
+            help='The unix user on the remote server.',
+            default='customer',
+        )
+        parser.add_argument(
+            '-p',
+            '--remote-password',
+            action='store',
+            help="The remote user's password.",
+            default='dA24zoB5anPj2JBcAn86bTVCCWSjhN4JDsKPyD7JaFuopvxHupWKMLk7kPQHmsPSMAjonKiBStyRQ99fEEoSixzuCUBywhrcg7dDQvFot9cSWo7PimTM9BbS9vq49ATe',
+        )
+        parser.add_argument(
+            '-t',
+            '--timeout',
+            action='store',
+            help='The tunnel will timeout after this much seconds. Default to 8 hours.',
+            default=28800,
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+
+        # We need a retry mechanism just in case there's a port collision on the remote server, in which case we make a new attempt with a different random port
+        attempt = 1
+        max_retries = 3
+        result = -1
+        while result != 0:
+            if attempt > max_retries:
+                logger.critical(f'Max retries ({max_retries}) exceeded, exiting.')
+                exit(1)
+
+            result = self.open_access(parsed_args)
+
+    def open_access(self, parsed_args):
+        remote_port = random.randint(22022, 22222)
+
+        ssh_command = f'ssh -o StrictHostKeyChecking=no -o PreferredAuthentications=password -o ExitOnForwardFailure=yes -o ServerAliveInterval=15 -o ServerAliveCountMax=10 -o ControlMaster=no {parsed_args.remote_user}@{parsed_args.remote_server} -p {parsed_args.remote_server_port} -R0.0.0.0:{remote_port}:localhost:{parsed_args.local_port} sleep infinity'
+
+        full_command = f"timeout {parsed_args.timeout} sshpass -e {ssh_command}"
+
+        human_readable_timeout = time.strftime(
+            "%H:%M:%S", time.gmtime(parsed_args.timeout)
+        )
+
+        logger.info(
+            f'''Access will open now. To connect as the 'root' user on the current server, one can use the following command:
+
+    ssh root@{parsed_args.remote_server} -p {remote_port}
+
+Keep the terminal open and it''ll last for {human_readable_timeout}. Close the terminal or hit Ctrl-C to cut it.'''
+        )
+
+        logger.debug(
+            f'''Opening the access using this command:
+    {full_command}'''
+        )
+
+        result = call(
+            full_command.split(' '), env={'SSHPASS': parsed_args.remote_password}
+        )
+
+        if result != 0:
+            logger.error("Couldn't open the access !")
+
+        return result

--- a/wazo_debug/main.py
+++ b/wazo_debug/main.py
@@ -12,7 +12,7 @@ class WazoDebugApp(App):
         super().__init__(
             description='Wazo Debug',
             command_manager=CommandManager('wazo_debug.commands'),
-            version='1.0.0',
+            version='1.1.0',
             deferred_help=True,
         )
 


### PR DESCRIPTION
# Why

As a support guy, I want an easy way to connect to a Wazo Platform, even behind NAT or Firewall

# Result

Upper half of the screenshot is the command to enable the access from the Wazo Platform, executed by the Platform's owner
Lower half of the screenshot is the connection from the support's terminal

![image](https://user-images.githubusercontent.com/1872031/124938898-f6359900-e008-11eb-8943-84f240e13ccd.png)
