### PR TITLE
access: handle CTRL-C more gracefully

### DIFF
--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -138,5 +138,7 @@ Keep the terminal open and it'll last for {human_readable_timeout}. Close the te
             logger.debug('stdout: %s', e.stdout)
             logger.error('stderr: %s', e.stderr)
             return e.returncode
+        except KeyboardInterrupt:
+            logger.debug('KeyboardInterrupt (CTRL-C)')
 
         return 0


### PR DESCRIPTION
Why:

* CTRL-C would print a long Traceback
* CTRL-C is the normal flow for wazo-debug access
