### PR TITLE
WAZO-2636 Pull request for access-close-after-kill

### DIFF
--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -110,8 +110,11 @@ class AccessCommand(Command):
             parsed_args.remote_server,
             'sleep infinity',
         ]
-
-        full_command = ['timeout', str(parsed_args.timeout)] + ssh_command
+        full_command = [
+            'timeout',
+            '--foreground',
+            str(parsed_args.timeout),
+        ] + ssh_command
 
         human_readable_timeout = time.strftime(
             "%H:%M:%S", time.gmtime(parsed_args.timeout)

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -64,6 +64,7 @@ class AccessCommand(Command):
             '-t',
             '--timeout',
             action='store',
+            type=int,
             help='The tunnel will timeout after this much seconds. Defaults to 8 hours.',
             default=28800,
         )
@@ -107,8 +108,8 @@ class AccessCommand(Command):
             parsed_args.identity,
             '-R',
             f'0.0.0.0:{remote_port}:localhost:{parsed_args.local_port}',
+            '-N',
             parsed_args.remote_server,
-            'sleep infinity',
         ]
         full_command = [
             'timeout',


### PR DESCRIPTION
## access: close the SSH tunnel after CTRL-C


## access: simplify ssh command

Why:

* -N means "run no command and leave the tunnel open", which is what we
want