### PR TITLE
WAZO-2707 Pull request for access-connection-timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ capture file will be printed on the console.
 ```
 wazo-debug access
 ```
+
+### Exit status
+
+* Exit status `1`: Tunnel creation failed on all retries
+* Exit status `2`: Tunnel connectivity check failed: the server cannot reach the SSH reverse-proxy.

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -128,7 +128,7 @@ Opening the access using this command:
             subprocess.run(ssh_command, check=True)
         except subprocess.CalledProcessError:
             logger.error("Couldn't open the access !")
-            exit(1)
+            exit(2)
         except KeyboardInterrupt:
             logger.debug('KeyboardInterrupt (CTRL-C)')
 

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -177,7 +177,7 @@ Access will open now. To connect as the 'root' user on the current server, one c
 Keep the terminal open and it'll last for {human_readable_timeout}. Close the terminal or hit Ctrl-C to cut it.'''
         )
         try:
-            subprocess.run(full_command)
+            subprocess.run(full_command, check=True)
         except subprocess.CalledProcessError as e:
             logger.error("Couldn't open the access !")
             logger.debug('stdout: %s', e.stdout)

--- a/wazo_debug/access.py
+++ b/wazo_debug/access.py
@@ -68,6 +68,14 @@ class AccessCommand(Command):
             help='The tunnel will timeout after this much seconds. Defaults to 8 hours.',
             default=28800,
         )
+        parser.add_argument(
+            '-c',
+            '--connect-timeout',
+            action='store',
+            type=int,
+            help='The tunnel will stop attempting to establish after this much seconds. Defaults to 2 seconds.',
+            default=2,
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -100,7 +108,7 @@ class AccessCommand(Command):
             '-o',
             'ControlMaster=no',
             '-o',
-            'ConnectTimeout=2',
+            f'ConnectTimeout={parsed_args.connect_timeout}',
             '-l',
             parsed_args.remote_user,
             '-p',
@@ -141,6 +149,8 @@ Opening the access using this command:
             'ServerAliveCountMax=10',
             '-o',
             'ControlMaster=no',
+            '-o',
+            f'ConnectTimeout={parsed_args.connect_timeout}',
             '-l',
             parsed_args.remote_user,
             '-p',


### PR DESCRIPTION
## access: check network connectivity before opening SSH tunnel

Why:

* If a firewall blocks outgoing packets, the tunnel cannot be
established

## access: fix retrying mechanism

Why:

* the open_access() method always returned 0

## access: make connect timeout configurable

Why:

* If the server is loaded, it may need remote help.
* If the server is loaded, it may take some time to process the
CPU/network packets needed for the tunnel to establish.

## access: document exit status