### PR TITLE
pre-commit: bump mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: "3.11"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Update tooling**
> 
> - Bumps `mypy` pre-commit hook from `v0.991` to `v1.19.1` in `.pre-commit-config.yaml` (Python `3.11` still targeted)
> 
> No code or runtime changes; tooling/version-only update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6793bda2e43d8ad372e147e17aa03f52258771bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->