### PR TITLE
collect: compute size before creating tarball, reject if not enough fs space

### DIFF
--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -61,22 +61,25 @@ def check_free_space(temp_directory, output_file):
         if not _has_enough_free_space(temp_directory, combined_bytes):
             raise RuntimeError(
                 f'Not enough free space on filesystem hosting "{temp_directory}" '
-                f'for uncompressed data + compressed tarball '
-                f'({combined_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+                f'for uncompressed data + compressed tarball: '
+                f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
+                f'{_format_bytes(combined_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
             )
         return
 
     if not _has_enough_free_space(temp_directory, uncompressed_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{temp_directory}" '
-            f'for uncompressed data '
-            f'({uncompressed_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+            f'for uncompressed data: '
+            f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
+            f'{_format_bytes(uncompressed_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
     if not _has_enough_free_space(output_directory, compressed_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{output_directory}" '
-            f'for compressed tarball '
-            f'({compressed_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+            f'for compressed tarball: '
+            f'{_format_bytes(shutil.disk_usage(output_directory).free)} available, '
+            f'{_format_bytes(compressed_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
 
 
@@ -84,14 +87,23 @@ def _has_enough_free_space(directory, data_bytes):
     free_bytes = shutil.disk_usage(directory).free
     needed_bytes = data_bytes + FREE_SPACE_BUFFER_BYTES
     logger.info(
-        'Free space check on "%s": need %d bytes (data %d + buffer %d), have %d bytes',
+        'Free space check on "%s": need %s (data %s + buffer %s), have %s',
         directory,
-        needed_bytes,
-        data_bytes,
-        FREE_SPACE_BUFFER_BYTES,
-        free_bytes,
+        _format_bytes(needed_bytes),
+        _format_bytes(data_bytes),
+        _format_bytes(FREE_SPACE_BUFFER_BYTES),
+        _format_bytes(free_bytes),
     )
     return free_bytes >= needed_bytes
+
+
+def _format_bytes(n: int) -> str:
+    size = float(n)
+    for unit in ('B', 'KiB', 'MiB', 'GiB'):
+        if abs(size) < 1024:
+            return f'{size:.1f} {unit}'
+        size /= 1024
+    return f'{size:.1f} TiB'
 
 
 def _existing_ancestor(path):

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -16,8 +16,6 @@ from cliff.command import Command
 logger = logging.getLogger(__name__)
 
 FREE_SPACE_BUFFER_BYTES = 500 * 1024 * 1024  # 500 MB safety buffer
-# Worst-case compressed-to-uncompressed ratio for the output tarball
-TARBALL_COMPRESSION_RATIO = 0.80
 ASTERISK_LOG_DIR = '/var/log/asterisk'
 
 
@@ -51,36 +49,37 @@ class CollectCommand(Command):
 
 
 def check_free_space(temp_directory, output_file):
-    uncompressed_bytes = compute_gathering_size()
-    compressed_bytes = int(uncompressed_bytes * TARBALL_COMPRESSION_RATIO)
+    # `tar caf` auto-detects compression from the output suffix, so we assume
+    # the worst case: an uncompressed tarball whose size matches the source.
+    required_bytes = compute_gathering_size()
     output_directory = _existing_ancestor(output_file)
 
     if _same_filesystem(temp_directory, output_directory):
         # Tarball is built while the uncompressed copy still lives in temp_directory,
         # so both must fit on the shared filesystem at the same time.
-        combined_bytes = uncompressed_bytes + compressed_bytes
+        combined_bytes = required_bytes * 2
         if not _has_enough_free_space(temp_directory, combined_bytes):
             raise RuntimeError(
                 f'Not enough free space on filesystem hosting "{temp_directory}" '
-                f'for uncompressed data + compressed tarball: '
+                f'for gathered data + tarball: '
                 f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
                 f'{_format_bytes(combined_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
             )
         return
 
-    if not _has_enough_free_space(temp_directory, uncompressed_bytes):
+    if not _has_enough_free_space(temp_directory, required_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{temp_directory}" '
-            f'for uncompressed data: '
+            f'for gathered data: '
             f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
-            f'{_format_bytes(uncompressed_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
+            f'{_format_bytes(required_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
-    if not _has_enough_free_space(output_directory, compressed_bytes):
+    if not _has_enough_free_space(output_directory, required_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{output_directory}" '
-            f'for compressed tarball: '
+            f'for tarball: '
             f'{_format_bytes(shutil.disk_usage(output_directory).free)} available, '
-            f'{_format_bytes(compressed_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
+            f'{_format_bytes(required_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
 
 

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -7,6 +7,7 @@ import glob
 import logging
 import os
 import shutil
+import stat
 import tempfile
 from subprocess import call
 
@@ -152,14 +153,12 @@ def _engine_info_source_paths():
 
 
 def _path_size(path):
-    if os.path.islink(path):
+    info = _lstat(path)
+    if info is None or stat.S_ISLNK(info.st_mode):
         return 0
-    if os.path.isfile(path):
-        try:
-            return os.path.getsize(path)
-        except OSError:
-            return 0
-    if not os.path.isdir(path):
+    if stat.S_ISREG(info.st_mode):
+        return _allocated_bytes(info)
+    if not stat.S_ISDIR(info.st_mode):
         return 0
 
     is_asterisk_log_dir = path == ASTERISK_LOG_DIR
@@ -172,14 +171,24 @@ def _path_size(path):
         for name in files:
             if is_asterisk_log_dir and not fnmatch.fnmatch(name, 'full*'):
                 continue
-            full = os.path.join(root, name)
-            if os.path.islink(full):
+            file_info = _lstat(os.path.join(root, name))
+            if file_info is None or stat.S_ISLNK(file_info.st_mode):
                 continue
-            try:
-                total += os.path.getsize(full)
-            except OSError:
-                continue
+            total += _allocated_bytes(file_info)
     return total
+
+
+def _lstat(path):
+    try:
+        return os.lstat(path)
+    except OSError:
+        return None
+
+
+def _allocated_bytes(info: os.stat_result):
+    # Use st_blocks (512-byte units) rather than st_size so sparse files and
+    # block-rounding overhead are reflected in the estimate.
+    return info.st_blocks * 512
 
 
 def gather_facts(gathering_directory):

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -1,16 +1,21 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
+import fnmatch
 import glob
 import logging
 import os
+import shutil
 import tempfile
 from subprocess import call
 
 from cliff.command import Command
 
 logger = logging.getLogger(__name__)
+
+FREE_SPACE_BUFFER_BYTES = 500 * 1024 * 1024  # 500 MB safety buffer
+ASTERISK_LOG_DIR = '/var/log/asterisk'
 
 
 class CollectCommand(Command):
@@ -31,6 +36,8 @@ class CollectCommand(Command):
         with tempfile.TemporaryDirectory(prefix='wazo-debug-') as temp_directory:
             logger.info('Created temporary directory: "%s"', temp_directory)
 
+            check_free_space(temp_directory)
+
             gathering_directory = os.path.join(temp_directory, 'wazo-debug')
             os.mkdir(gathering_directory)
 
@@ -38,6 +45,86 @@ class CollectCommand(Command):
             bundle_facts(temp_directory, parsed_args.output_file)
 
             logger.info('Removing temporary directory: "%s"', temp_directory)
+
+
+def check_free_space(target_directory):
+    required_bytes = compute_gathering_size()
+    free_bytes = shutil.disk_usage(target_directory).free
+    needed_bytes = required_bytes + FREE_SPACE_BUFFER_BYTES
+    logger.info(
+        'Estimated gathered data size: %d bytes; free space on "%s": %d bytes',
+        required_bytes,
+        target_directory,
+        free_bytes,
+    )
+    if free_bytes < needed_bytes:
+        raise RuntimeError(
+            f'Not enough free space on filesystem hosting "{target_directory}": '
+            f'{free_bytes} bytes available, but {needed_bytes} bytes are required '
+            f'({required_bytes} bytes of data + {FREE_SPACE_BUFFER_BYTES} bytes buffer).'
+        )
+
+
+def compute_gathering_size():
+    paths = (
+        _log_source_paths()
+        + _config_source_paths()
+        + glob.glob('/usr/share/wazo/WAZO-VERSION')
+    )
+    return sum(_path_size(p) for p in paths)
+
+
+def _log_source_paths():
+    return (
+        glob.glob('/var/log/asterisk')
+        + glob.glob('/var/log/nginx')
+        + glob.glob('/var/log/rabbitmq')
+        + glob.glob('/var/log/syslog*')
+        + glob.glob('/var/log/wazo-*')
+        + glob.glob('/var/log/xivo-*')
+        + glob.glob('/var/log/fail2ban*')
+        + glob.glob('/var/www/munin')
+    )
+
+
+def _config_source_paths():
+    return (
+        glob.glob('/etc/wazo-*')
+        + glob.glob('/etc/xivo*')
+        + glob.glob('/etc/asterisk')
+        + glob.glob('/etc/nginx')
+    )
+
+
+def _path_size(path):
+    if os.path.islink(path):
+        return 0
+    if os.path.isfile(path):
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return 0
+    if not os.path.isdir(path):
+        return 0
+
+    is_asterisk_log_dir = path == ASTERISK_LOG_DIR
+    total = 0
+    for root, dirs, files in os.walk(path):
+        if is_asterisk_log_dir and root != path:
+            # rsync filter excludes asterisk subdirectories (only keeps full* at top level)
+            dirs[:] = []
+            continue
+        for name in files:
+            if is_asterisk_log_dir and not fnmatch.fnmatch(name, 'full*'):
+                continue
+            full = os.path.join(root, name)
+            if os.path.islink(full):
+                continue
+            try:
+                total += os.path.getsize(full)
+            except OSError:
+                continue
+    return total
 
 
 def gather_facts(gathering_directory):

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -54,46 +54,40 @@ def check_free_space(temp_directory, output_file):
     required_bytes = compute_gathering_size()
     output_directory = _existing_ancestor(output_file)
 
+    temp_directory_free_space = shutil.disk_usage(temp_directory).free
+    output_directory_free_space = shutil.disk_usage(output_directory).free
+
     if _same_filesystem(temp_directory, output_directory):
         # Tarball is built while the uncompressed copy still lives in temp_directory,
         # so both must fit on the shared filesystem at the same time.
         combined_bytes = required_bytes * 2
-        if not _has_enough_free_space(temp_directory, combined_bytes):
+        if not _has_enough_free_space(temp_directory_free_space, combined_bytes):
             raise RuntimeError(
                 f'Not enough free space on filesystem hosting "{temp_directory}" '
                 f'for gathered data + tarball: '
-                f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
+                f'{_format_bytes(temp_directory_free_space)} available, '
                 f'{_format_bytes(combined_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
             )
         return
 
-    if not _has_enough_free_space(temp_directory, required_bytes):
+    if not _has_enough_free_space(temp_directory_free_space, required_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{temp_directory}" '
             f'for gathered data: '
-            f'{_format_bytes(shutil.disk_usage(temp_directory).free)} available, '
+            f'{_format_bytes(temp_directory_free_space)} available, '
             f'{_format_bytes(required_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
-    if not _has_enough_free_space(output_directory, required_bytes):
+    if not _has_enough_free_space(output_directory_free_space, required_bytes):
         raise RuntimeError(
             f'Not enough free space on filesystem hosting "{output_directory}" '
             f'for tarball: '
-            f'{_format_bytes(shutil.disk_usage(output_directory).free)} available, '
+            f'{_format_bytes(output_directory_free_space)} available, '
             f'{_format_bytes(required_bytes + FREE_SPACE_BUFFER_BYTES)} required.'
         )
 
 
-def _has_enough_free_space(directory, data_bytes):
-    free_bytes = shutil.disk_usage(directory).free
+def _has_enough_free_space(free_bytes, data_bytes):
     needed_bytes = data_bytes + FREE_SPACE_BUFFER_BYTES
-    logger.info(
-        'Free space check on "%s": need %s (data %s + buffer %s), have %s',
-        directory,
-        _format_bytes(needed_bytes),
-        _format_bytes(data_bytes),
-        _format_bytes(FREE_SPACE_BUFFER_BYTES),
-        _format_bytes(free_bytes),
-    )
     return free_bytes >= needed_bytes
 
 

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -66,11 +66,7 @@ def check_free_space(target_directory):
 
 
 def compute_gathering_size():
-    paths = (
-        _log_source_paths()
-        + _config_source_paths()
-        + glob.glob('/usr/share/wazo/WAZO-VERSION')
-    )
+    paths = _log_source_paths() + _config_source_paths() + _engine_info_source_paths()
     return sum(_path_size(p) for p in paths)
 
 
@@ -94,6 +90,10 @@ def _config_source_paths():
         + glob.glob('/etc/asterisk')
         + glob.glob('/etc/nginx')
     )
+
+
+def _engine_info_source_paths():
+    return glob.glob('/usr/share/wazo/WAZO-VERSION')
 
 
 def _path_size(path):
@@ -144,14 +144,7 @@ def gather_log_files(gathering_directory):
         ['rsync', '-a']
         + ['--include', 'asterisk/full*']
         + ['--exclude', 'asterisk/*']
-        + glob.glob('/var/log/asterisk')
-        + glob.glob('/var/log/nginx')
-        + glob.glob('/var/log/rabbitmq')
-        + glob.glob('/var/log/syslog*')
-        + glob.glob('/var/log/wazo-*')
-        + glob.glob('/var/log/xivo-*')
-        + glob.glob('/var/log/fail2ban*')
-        + glob.glob('/var/www/munin')
+        + _log_source_paths()
         + [gathering_log_directory]
     )
     call(command)
@@ -163,21 +156,14 @@ def gather_config_files(gathering_directory):
     gathering_config_directory = os.path.join(gathering_directory, 'config')
     os.mkdir(gathering_config_directory)
 
-    command = (
-        ['rsync', '-a']
-        + glob.glob('/etc/wazo-*')
-        + glob.glob('/etc/xivo*')
-        + glob.glob('/etc/asterisk')
-        + glob.glob('/etc/nginx')
-        + [gathering_config_directory]
-    )
+    command = ['rsync', '-a'] + _config_source_paths() + [gathering_config_directory]
     call(command)
 
 
 def gather_engine_info(gathering_directory):
     logger.info('Gathering engine information...')
 
-    command = ['rsync', '-a', '/usr/share/wazo/WAZO-VERSION', gathering_directory]
+    command = ['rsync', '-a'] + _engine_info_source_paths() + [gathering_directory]
     call(command)
 
     command = ['timedatectl', 'show']

--- a/wazo_debug/collect.py
+++ b/wazo_debug/collect.py
@@ -15,6 +15,8 @@ from cliff.command import Command
 logger = logging.getLogger(__name__)
 
 FREE_SPACE_BUFFER_BYTES = 500 * 1024 * 1024  # 500 MB safety buffer
+# Worst-case compressed-to-uncompressed ratio for the output tarball
+TARBALL_COMPRESSION_RATIO = 0.80
 ASTERISK_LOG_DIR = '/var/log/asterisk'
 
 
@@ -36,7 +38,7 @@ class CollectCommand(Command):
         with tempfile.TemporaryDirectory(prefix='wazo-debug-') as temp_directory:
             logger.info('Created temporary directory: "%s"', temp_directory)
 
-            check_free_space(temp_directory)
+            check_free_space(temp_directory, parsed_args.output_file)
 
             gathering_directory = os.path.join(temp_directory, 'wazo-debug')
             os.mkdir(gathering_directory)
@@ -47,22 +49,63 @@ class CollectCommand(Command):
             logger.info('Removing temporary directory: "%s"', temp_directory)
 
 
-def check_free_space(target_directory):
-    required_bytes = compute_gathering_size()
-    free_bytes = shutil.disk_usage(target_directory).free
-    needed_bytes = required_bytes + FREE_SPACE_BUFFER_BYTES
+def check_free_space(temp_directory, output_file):
+    uncompressed_bytes = compute_gathering_size()
+    compressed_bytes = int(uncompressed_bytes * TARBALL_COMPRESSION_RATIO)
+    output_directory = _existing_ancestor(output_file)
+
+    if _same_filesystem(temp_directory, output_directory):
+        # Tarball is built while the uncompressed copy still lives in temp_directory,
+        # so both must fit on the shared filesystem at the same time.
+        combined_bytes = uncompressed_bytes + compressed_bytes
+        if not _has_enough_free_space(temp_directory, combined_bytes):
+            raise RuntimeError(
+                f'Not enough free space on filesystem hosting "{temp_directory}" '
+                f'for uncompressed data + compressed tarball '
+                f'({combined_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+            )
+        return
+
+    if not _has_enough_free_space(temp_directory, uncompressed_bytes):
+        raise RuntimeError(
+            f'Not enough free space on filesystem hosting "{temp_directory}" '
+            f'for uncompressed data '
+            f'({uncompressed_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+        )
+    if not _has_enough_free_space(output_directory, compressed_bytes):
+        raise RuntimeError(
+            f'Not enough free space on filesystem hosting "{output_directory}" '
+            f'for compressed tarball '
+            f'({compressed_bytes} bytes + {FREE_SPACE_BUFFER_BYTES} buffer required).'
+        )
+
+
+def _has_enough_free_space(directory, data_bytes):
+    free_bytes = shutil.disk_usage(directory).free
+    needed_bytes = data_bytes + FREE_SPACE_BUFFER_BYTES
     logger.info(
-        'Estimated gathered data size: %d bytes; free space on "%s": %d bytes',
-        required_bytes,
-        target_directory,
+        'Free space check on "%s": need %d bytes (data %d + buffer %d), have %d bytes',
+        directory,
+        needed_bytes,
+        data_bytes,
+        FREE_SPACE_BUFFER_BYTES,
         free_bytes,
     )
-    if free_bytes < needed_bytes:
-        raise RuntimeError(
-            f'Not enough free space on filesystem hosting "{target_directory}": '
-            f'{free_bytes} bytes available, but {needed_bytes} bytes are required '
-            f'({required_bytes} bytes of data + {FREE_SPACE_BUFFER_BYTES} bytes buffer).'
-        )
+    return free_bytes >= needed_bytes
+
+
+def _existing_ancestor(path):
+    path = os.path.abspath(path)
+    while not os.path.exists(path):
+        parent = os.path.dirname(path)
+        if parent == path:
+            break
+        path = parent
+    return path
+
+
+def _same_filesystem(path_a, path_b):
+    return os.stat(path_a).st_dev == os.stat(path_b).st_dev
 
 
 def compute_gathering_size():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Operational guardrails on a support/debug CLI; failures are explicit before heavy I/O, with no auth or production traffic impact.
> 
> **Overview**
> **`wazo-debug collect`** now estimates how much data will be gathered and **fails early** with a clear `RuntimeError` if disk space is insufficient, instead of filling `/tmp` or the output path mid-run.
> 
> Before `gather_facts`, **`check_free_space`** compares free space on the temp dir and the output file’s filesystem (via **`shutil.disk_usage`** and **`st_dev`**). It assumes a worst-case tarball as large as the gathered tree (matching **`tar caf`** behavior). When temp and output share one filesystem, it requires room for **both** the staging copy and the archive (**`required_bytes * 2`**), plus a **500 MiB** buffer. Error messages use human-readable sizes from **`_format_bytes`**.
> 
> **`compute_gathering_size`** walks the same log/config/engine paths as rsync, centralized in **`_log_source_paths`**, **`_config_source_paths`**, and **`_engine_info_source_paths`**. Size uses **`st_blocks * 512`** (allocated blocks) and mirrors the Asterisk rsync rules: only top-level **`full*`** files under **`/var/log/asterisk`**, no subdirs. Gather commands were updated to use these helpers so estimates match what is actually copied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903f3e1e54bbdb6a1a4b397e88b15acf356bd1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->